### PR TITLE
Remove unused method

### DIFF
--- a/lib/challah/jwt/technique.rb
+++ b/lib/challah/jwt/technique.rb
@@ -22,10 +22,6 @@ module Challah
       def user_model
         @user_model ||= Challah.user
       end
-
-      def token_provided?(session)
-        session.request.headers["Authorization"] =~ TOKEN_REGEX
-      end
     end
   end
 end


### PR DESCRIPTION
Remove `token_provided?` private method from the technique. It is unused (and was never used?) and can only cause confusion.